### PR TITLE
TYPEORM-1: Executing the migrations generated

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "start:swc": "nest start -b swc -w --type-check",
     "start:repl": "nest start --entryFile repl",
     "typeorm": "npm run build && npx typeorm -d dist/data/data.source.js",
-    "migration:generate": "npm run typeorm -- migration:generate"
+    "migration:generate": "npm run typeorm -- migration:generate",
+    "migration:run": "npm run typeorm -- migration:run",
+    "migration:show": "npm run typeorm -- migration:show",
+    "migration:revert": "npm run typeorm -- migration:revert"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/src/data/data.source.ts
+++ b/src/data/data.source.ts
@@ -2,7 +2,7 @@ import { DataSource, DataSourceOptions } from 'typeorm';
 export const dbdatasource: DataSourceOptions = {
   // TypeORM PostgreSQL DB Drivers
   type: 'postgres',
-  host: 'postgres_db',
+  host: 'localhost',
   port: 5432,
   username: 'demo_user',
   password: 'demo_password',

--- a/src/migrations/1708658704999-user.ts
+++ b/src/migrations/1708658704999-user.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class User1708658704999 implements MigrationInterface {
+    name = 'User1708658704999'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "users" ("userId" SERIAL NOT NULL, "username" character varying NOT NULL, "password" character varying NOT NULL, CONSTRAINT "PK_8bf09ba754322ab9c22a215c919" PRIMARY KEY ("userId"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "users"`);
+    }
+
+}


### PR DESCRIPTION
Migrations were generated automatically instead of manually, so some table columns might lack proper description